### PR TITLE
Fix type for u64

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -207,7 +207,7 @@ extern "C" {
   KLEE_TRACE_PARAM_PROTO(_i32, int32_t);
   KLEE_TRACE_PARAM_PROTO(_u32, uint32_t);
   KLEE_TRACE_PARAM_PROTO(_i64, int64_t);
-  KLEE_TRACE_PARAM_PROTO(_u64, int64_t);
+  KLEE_TRACE_PARAM_PROTO(_u64, uint64_t);
 #undef KLEE_TRACE_PARAM_PROTO
   void klee_trace_param_ptr(void* ptr, int width, const char* name);
   typedef enum TracingDirection {


### PR DESCRIPTION
I noticed the u64 tracing function says it takes an i64 instead of u64.

@SolalPirelli, maybe you want to review?