### PR TITLE
Several debug workflow improvements

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -360,6 +360,7 @@ public:
   void addConstraint(ref<Expr> e) { constraints.addConstraint(e); }
 
   bool merge(const ExecutionState &b);
+  void dumpStack() const;
   void dumpStack(llvm::raw_ostream &out) const;
   bool isAccessibleAddr(ref<Expr> addr) const;
   ref<Expr> readMemoryChunk(ref<Expr> addr,

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -475,6 +475,10 @@ bool ExecutionState::merge(const ExecutionState &b) {
   return true;
 }
 
+void ExecutionState::dumpStack() const {
+  dumpStack(llvm::errs());
+}
+
 void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
   unsigned idx = 0;
   const KInstruction *target = prevPC;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -442,6 +442,10 @@ private:
     terminateStateOnError(state, message, Exec, NULL, info);
   }
 
+  // Record state as a test case and continue execution.
+  void recordState(ExecutionState &state, const llvm::Twine &messaget,
+                   const char *suffix, const llvm::Twine &info = "");
+
   /// bindModuleConstants - Initialize the module constant table.
   void bindModuleConstants();
 

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -307,6 +307,7 @@ void klee_set_forking(unsigned enable) { }
   KLEE_TRACE_PARAM_PROTO(_i32, int32_t);
   KLEE_TRACE_PARAM_PROTO(_u32, uint32_t);
   KLEE_TRACE_PARAM_PROTO(_i64, int64_t);
+  KLEE_TRACE_PARAM_PROTO(_u64, uint64_t);
 #undef KLEE_TRACE_PARAM_PROTO
 void klee_trace_param_ptr(void* ptr, int width, const char* name) {}
   void klee_trace_param_ptr_directed(void* ptr, int width,


### PR DESCRIPTION
Here are a few debugging workflow improvements in my queue:

* Add no arg dumpStack for easy use from a debugger 
* Record symbolic indexing as a test case 
* Define u64 trace intrinsic during test replay

If you would prefer them as separate PRs, I can break them up as well.